### PR TITLE
Fix file descriptor closing in directoryTree.ts

### DIFF
--- a/src/fs/directoryTree.ts
+++ b/src/fs/directoryTree.ts
@@ -45,7 +45,7 @@ async function buildDirectoryTree(name: string, directoryPath: string): Promise<
       } else if (entry.isFile()) {
         try {
           const fd = await fs.promises.open(subPath, 'r')
-          fs.close(fd.fd);
+          await fd.close();
           entryData = {
             name: entry.name,
             path: subPath,

--- a/tests/directoryTree.test.ts
+++ b/tests/directoryTree.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import fs, { Stats } from 'fs'
+import path from 'path'
+import { FileHandle } from 'fs/promises'
+import { performDirectoryTreeCall } from '../src/fs/directoryTree.js'
+
+function createMockDirent(name: string, isDir: boolean = false): fs.Dirent {
+  return {
+    name,
+    parentPath: '/test/dir',
+    isDirectory: () => isDir,
+    isFile: () => !isDir,
+  } as unknown as fs.Dirent
+}
+
+describe('Directory Tree File Descriptor Handling', () => {
+  let mockClose: ReturnType<typeof vi.fn>;
+  let mockFileHandle: FileHandle;
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+
+    vi.spyOn(fs.promises, "access").mockResolvedValue(undefined)
+    vi.spyOn(fs.promises, 'stat').mockResolvedValue({
+      isFile: () => true,
+      isDirectory: () => true,
+    } as Stats)
+
+    const mockFiles = [
+      createMockDirent('file1.txt'),
+      createMockDirent('file2.pdf')
+    ];
+
+    vi.spyOn(fs.promises, "readdir").mockResolvedValue(mockFiles as unknown as fs.Dirent<Buffer<ArrayBufferLike>>[])
+
+    mockClose = vi.fn().mockResolvedValue(undefined)
+    mockFileHandle = {
+      fd: 16,
+      close: mockClose
+    } as unknown as FileHandle
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should properly close file descriptors when processing files', async () => {
+    const openSpy = vi.spyOn(fs.promises, "open").mockResolvedValue(mockFileHandle)
+
+    await performDirectoryTreeCall('/test/dir')
+
+    expect(openSpy).toHaveBeenCalledTimes(2)
+    expect(openSpy).toHaveBeenCalledWith(path.join('/test/dir', 'file1.txt'), 'r')
+    expect(openSpy).toHaveBeenCalledWith(path.join('/test/dir', 'file2.pdf'), 'r')
+
+    expect(mockClose).toHaveBeenCalledTimes(2)
+
+    const fsCloseSpy = vi.spyOn(fs, 'close')
+    expect(fsCloseSpy).not.toHaveBeenCalled()
+  })
+
+  it('should handle errors when opening files and continue processing', async () => {
+    const openSpy = vi.spyOn(fs.promises, "open")
+      .mockRejectedValueOnce(new Error('Permission denied'))
+      .mockResolvedValueOnce(mockFileHandle)
+
+    const result = await performDirectoryTreeCall('/test/dir')
+
+    expect(result.isError).toBe(false)
+
+    expect(openSpy).toHaveBeenCalledTimes(2)
+
+    expect(mockClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('should use fd.close() instead of fs.close(fd.fd)', async () => {
+    const specialMockClose = vi.fn().mockResolvedValue(undefined)
+    const specialMockFileHandle = {
+      fd: 42,
+      close: specialMockClose
+    } as unknown as FileHandle
+
+    vi.spyOn(fs.promises, "open").mockResolvedValue(specialMockFileHandle)
+
+    const fsCloseSpy = vi.spyOn(fs, 'close')
+
+    await performDirectoryTreeCall('/test/dir')
+
+    expect(specialMockClose).toHaveBeenCalledTimes(2)
+
+    expect(fsCloseSpy).not.toHaveBeenCalled()
+    expect(fsCloseSpy).not.toHaveBeenCalledWith(42)
+  })
+})


### PR DESCRIPTION
## Problem
The application was experiencing `EBADF` errors during garbage collection:

```
[Error: EBADF: Closing file descriptor 16 on garbage collection failed, close] {
  errno: -9,
  code: 'EBADF',
  syscall: 'close'
}
```

This occurred because file descriptors in `directoryTree.ts` were being improperly closed using a mix of Promise-based and callback-style Node.js file system APIs.

## Changes
- Fixed the file descriptor closing method in `src/fs/directoryTree.ts`
- Changed `fs.close(fd.fd)` to `await fd.close()` to properly close file handles obtained from `fs.promises.open()`
- Added comprehensive unit tests to verify proper file descriptor handling

## Why This Works
When using `fs.promises.open()`, it returns a `FileHandle` object that has its own `close()` method. The previous code was incorrectly extracting the raw file descriptor number (`fd.fd`) and passing it to `fs.close()`, which:
1. Didn't properly close the `FileHandle` object
2. Didn't wait for the close operation to complete (no `await`)

The fix ensures that:
1. The proper API is used to close the file handle
2. The close operation completes before continuing (due to `await`)

## Testing
Added unit tests that specifically verify:
- File descriptors are properly closed using `fd.close()` when processing files
- The code handles errors gracefully when opening files
- The `fs.close()` function is not called, which would be incorrect

All tests pass, confirming the fix works as expected.