### PR TITLE
Add support for new output formats: PDF/UA, HTML, and Markdown

### DIFF
--- a/src/dws/build.ts
+++ b/src/dws/build.ts
@@ -149,5 +149,3 @@ async function makeApiBuildCall(instructions: Instructions, fileReferences: Map<
     return callNutrientApi('build', formData)
   }
 }
-
-

--- a/src/dws/sign.ts
+++ b/src/dws/sign.ts
@@ -19,10 +19,10 @@ export async function performSignCall(
 ): Promise<CallToolResult> {
   try {
     // We resolve the output path first to fail early
-    const resolvedOutputPath = await resolveWriteFilePath(outputFilePath);
+    const resolvedOutputPath = await resolveWriteFilePath(outputFilePath)
 
     const formData = new FormData()
-    await addFileToFormData(formData, "file", filePath)
+    await addFileToFormData(formData, 'file', filePath)
 
     if (signatureOptions) {
       formData.append('data', JSON.stringify(signatureOptions))
@@ -51,7 +51,7 @@ export async function performSignCall(
  * @param filePath Path to the file to add
  * @returns Object with error information if any
  */
-export async function addFileToFormData(formData: FormData, fieldName: string, filePath: string, ) {
+export async function addFileToFormData(formData: FormData, fieldName: string, filePath: string) {
   try {
     const validatedPath = await resolveReadFilePath(filePath)
     const fileBuffer = await fs.promises.readFile(validatedPath)

--- a/src/fs/directoryTree.ts
+++ b/src/fs/directoryTree.ts
@@ -20,11 +20,13 @@ interface TreeEntry {
 export async function performDirectoryTreeCall(directoryPath: string): Promise<CallToolResult> {
   try {
     const validPath = await resolveReadDirectoryPath(directoryPath)
-    const treeData = await buildDirectoryTree("root", validPath)
+    const treeData = await buildDirectoryTree('root', validPath)
     if (treeData) {
       return createSuccessResponse(JSON.stringify(treeData.children, null, 2))
     } else {
-      return createErrorResponse(`Cannot read the directory tree, make sure to allow this application access to ${validPath}`)
+      return createErrorResponse(
+        `Cannot read the directory tree, make sure to allow this application access to ${validPath}`,
+      )
     }
   } catch (error) {
     return createErrorResponse(`Error: ${error instanceof Error ? error.message : String(error)}`)
@@ -38,14 +40,14 @@ async function buildDirectoryTree(name: string, directoryPath: string): Promise<
   try {
     const entries = await fs.promises.readdir(directoryPath, { withFileTypes: true })
     const promises = entries.map(async (entry) => {
-      let entryData: TreeEntry | null;
+      let entryData: TreeEntry | null
       const subPath = path.join(entry.parentPath, entry.name)
       if (entry.isDirectory()) {
         entryData = await buildDirectoryTree(entry.name, subPath)
       } else if (entry.isFile()) {
         try {
           const fd = await fs.promises.open(subPath, 'r')
-          await fd.close();
+          await fd.close()
           entryData = {
             name: entry.name,
             path: subPath,
@@ -63,13 +65,13 @@ async function buildDirectoryTree(name: string, directoryPath: string): Promise<
     })
 
     // Run the build Tree node for all the children concurrently
-    const results = await Promise.all(promises);
+    const results = await Promise.all(promises)
 
     return {
       name: name,
       path: directoryPath,
-      type: "directory",
-      children: results.filter((res) => res !== null)
+      type: 'directory',
+      children: results.filter((res) => res !== null),
     }
   } catch {
     // This is for the case where the folder doesn't allow us to list it's content

--- a/src/fs/sandbox.ts
+++ b/src/fs/sandbox.ts
@@ -17,12 +17,12 @@ export async function setSandboxDirectory(directory: string | null = null) {
 
   try {
     await fs.promises.access(resolvedDirectory)
-    await fs.promises.readdir(resolvedDirectory);
+    await fs.promises.readdir(resolvedDirectory)
   } catch {
     await fs.promises.mkdir(resolvedDirectory, { recursive: true })
   }
 
-  sandboxDirectory = resolvedDirectory;
+  sandboxDirectory = resolvedDirectory
 }
 
 function isInsideSandboxDirectory(filePath: string) {
@@ -71,7 +71,7 @@ export async function resolveReadDirectoryPath(dirPath: string): Promise<string>
   if (!stats.isDirectory()) {
     throw new Error(`Path is not a directory: ${resolvedDirPath}`)
   }
-  return resolvedDirPath;
+  return resolvedDirPath
 }
 
 /**
@@ -87,7 +87,7 @@ export async function resolveReadFilePath(filePath: string): Promise<string> {
   if (!stats.isFile()) {
     throw new Error(`Path is not a file: ${resolvedFilePath}`)
   }
-  return resolvedFilePath;
+  return resolvedFilePath
 }
 
 /**
@@ -100,22 +100,22 @@ export async function resolveWriteFilePath(filePath: string): Promise<string> {
   const resolvedFilePath = resolvePath(filePath)
   try {
     await fs.promises.access(resolvedFilePath)
-    const fd = await fs.promises.open(resolvedFilePath, 'r+');
-    await fd.close();
+    const fd = await fs.promises.open(resolvedFilePath, 'r+')
+    await fd.close()
   } catch {
     const outputDir = path.dirname(resolvedFilePath)
-    let createdFolderPath: string | undefined;
+    let createdFolderPath: string | undefined
     try {
       await fs.promises.access(outputDir)
     } catch {
       createdFolderPath = await fs.promises.mkdir(outputDir, { recursive: true })
     }
-    await fs.promises.writeFile(resolvedFilePath, 'test');
+    await fs.promises.writeFile(resolvedFilePath, 'test')
     if (createdFolderPath) {
-      await fs.promises.rm(createdFolderPath, {recursive: true})
+      await fs.promises.rm(createdFolderPath, { recursive: true })
     } else {
-      await fs.promises.unlink(resolvedFilePath);
+      await fs.promises.unlink(resolvedFilePath)
     }
   }
-  return resolvedFilePath;
+  return resolvedFilePath
 }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -426,13 +426,6 @@ export const PDFUAOutputSchema = BasePDFOutputSchema.extend({
 export const JSONContentOutputSchema = z.object({
   type: z.literal('json-content').describe('Output as JSON with document contents.'),
   plainText: z.boolean().optional().default(true).describe('Extract document text. Text is extracted via OCR process.'),
-  structuredText: z
-    .boolean()
-    .optional()
-    .default(false)
-    .describe(
-      'Extract structured document text. This includes text words, characters, lines and paragraphs. Use one of `plainText`, `keyValuePairs`, or `tables`. at a time.',
-    ),
   keyValuePairs: z
     .boolean()
     .optional()
@@ -453,6 +446,9 @@ export const JSONContentOutputSchema = z.object({
       z.array(z.string()).describe('Languages for OCR text extraction.'),
     ])
     .optional(),
+
+  // Structure text uses many chars, and often overflows the context length of an LLM. We will not support this for now.
+  // structuredText: z.boolean().optional().default(false).describe('Extracts text with positional data.'),
 })
 
 export const OfficeOutputSchema = z.object({

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -425,16 +425,14 @@ export const PDFUAOutputSchema = BasePDFOutputSchema.extend({
 
 export const JSONContentOutputSchema = z.object({
   type: z.literal('json-content').describe('Output as JSON with document contents.'),
-  plainText: z
-    .boolean()
-    .optional()
-    .default(true)
-    .describe('Extract document text. Text is extracted via OCR process.'),
+  plainText: z.boolean().optional().default(true).describe('Extract document text. Text is extracted via OCR process.'),
   structuredText: z
     .boolean()
     .optional()
     .default(false)
-    .describe('Extract structured document text. This includes text words, characters, lines and paragraphs. Use one of `plainText`, `keyValuePairs`, or `tables`. at a time.'),
+    .describe(
+      'Extract structured document text. This includes text words, characters, lines and paragraphs. Use one of `plainText`, `keyValuePairs`, or `tables`. at a time.',
+    ),
   keyValuePairs: z
     .boolean()
     .optional()
@@ -446,7 +444,9 @@ export const JSONContentOutputSchema = z.object({
     .boolean()
     .optional()
     .default(true)
-    .describe('Extract tabular data from the document. Use one of `plainText`, `keyValuePairs`, or `tables`. at a time.'),
+    .describe(
+      'Extract tabular data from the document. Use one of `plainText`, `keyValuePairs`, or `tables`. at a time.',
+    ),
   language: z
     .union([
       z.string().describe('Language for OCR text extraction.'),
@@ -466,8 +466,8 @@ export const HTMLOutputSchema = z.object({
     .optional()
     .describe(
       'The layout type to use for conversion to HTML. ' +
-      '`page` layout keeps the original structure of the document, segmented by page. ' +
-      '`reflow` layout converts the document into a continuous flow of text, without page breaks.',
+        '`page` layout keeps the original structure of the document, segmented by page. ' +
+        '`reflow` layout converts the document into a continuous flow of text, without page breaks.',
     ),
 })
 

--- a/tests/build-api-examples.test.ts
+++ b/tests/build-api-examples.test.ts
@@ -73,7 +73,6 @@ describe('performBuildCall with build-api-examples', () => {
 
   const jsonOutputExamples: { name: string; example: BuildAPIArgs }[] = [
     { name: 'jsonContentExtractionExample', example: examples.jsonContentExtractionExample },
-    { name: 'jsonContentWithStructuredTextExample', example: examples.jsonContentWithStructuredTextExample },
     { name: 'jsonContentKeyValuePairsExample', example: examples.jsonContentKeyValuePairsExample },
     { name: 'jsonContentTablesOnlyExample', example: examples.jsonContentTablesOnlyExample },
     { name: 'jsonContentMultiLanguageExample', example: examples.jsonContentMultiLanguageExample },

--- a/tests/build-api-examples.test.ts
+++ b/tests/build-api-examples.test.ts
@@ -19,7 +19,7 @@ describe('performBuildCall with build-api-examples', () => {
 
   afterEach(async () => {
     // A naive way to do rate limiting.
-    return await new Promise((resolve) => setTimeout(resolve, 5000))
+    return await new Promise((resolve) => setTimeout(resolve, 10000))
   }, 20000)
 
   const fileOutputExamples: { name: string; example: BuildAPIArgs }[] = [

--- a/tests/build-api-examples.test.ts
+++ b/tests/build-api-examples.test.ts
@@ -59,10 +59,24 @@ describe('performBuildCall with build-api-examples', () => {
     { name: 'mixedFileTypesExample', example: examples.mixedFileTypesExample },
     { name: 'ocrAndRedactionsExample', example: examples.ocrAndRedactionsExample },
     { name: 'disabledImagesExample', example: examples.disabledImagesExample },
+    { name: 'pdfUAExample', example: examples.pdfUAExample },
+    { name: 'pdfUAWithPasswordExample', example: examples.pdfUAWithPasswordExample },
+    { name: 'htmlPageLayoutExample', example: examples.htmlPageLayoutExample },
+    { name: 'htmlReflowLayoutExample', example: examples.htmlReflowLayoutExample },
+    { name: 'htmlDefaultExample', example: examples.htmlDefaultExample },
+    { name: 'markdownExample', example: examples.markdownExample },
+    { name: 'markdownMultipleSourcesExample', example: examples.markdownMultipleSourcesExample },
+    { name: 'ocrToHtmlExample', example: examples.ocrToHtmlExample },
+    { name: 'watermarkToMarkdownExample', example: examples.watermarkToMarkdownExample },
+    { name: 'redactedPdfUAExample', example: examples.redactedPdfUAExample },
   ]
 
   const jsonOutputExamples: { name: string; example: BuildAPIArgs }[] = [
     { name: 'jsonContentExtractionExample', example: examples.jsonContentExtractionExample },
+    { name: 'jsonContentWithStructuredTextExample', example: examples.jsonContentWithStructuredTextExample },
+    { name: 'jsonContentKeyValuePairsExample', example: examples.jsonContentKeyValuePairsExample },
+    { name: 'jsonContentTablesOnlyExample', example: examples.jsonContentTablesOnlyExample },
+    { name: 'jsonContentMultiLanguageExample', example: examples.jsonContentMultiLanguageExample },
   ]
 
   it.each(fileOutputExamples)('should process $name', async ({ example }) => {
@@ -95,8 +109,8 @@ describe('performBuildCall with build-api-examples', () => {
           expect.objectContaining({
             // The content type can be 'text' or 'json' depending on how performBuildCall processes the JSON string
             type: 'text',
-            // For text type, it should contain success message; for json type, it should have the result property
-            text: expect.stringContaining('Dummy PDF file'),
+            // For text type, it should contain success message for plain text; and pages array of pageIndexs for structured output
+            text: expect.toBeOneOf([expect.stringContaining('Dummy PDF file'), expect.stringContaining('pageIndex')]),
           }),
         ]),
       }),

--- a/tests/build-api-examples.ts
+++ b/tests/build-api-examples.ts
@@ -8,7 +8,7 @@ import { BuildAPIArgs } from '../src/schemas.js'
  * - Different file types and formats
  * - Various instruction configurations
  * - All action types (OCR, rotation, watermarks, flattening, etc.)
- * - All output formats (PDF, PDF/A, image, JSON, Office)
+ * - All output formats (PDF, PDF/A, PDF/UA, image, JSON, Office, HTML, Markdown)
  * - Various combinations of options and parameters
  * - Edge cases and special use cases
  */
@@ -108,6 +108,7 @@ export const jsonContentExtractionExample: BuildAPIArgs = {
     output: {
       type: 'json-content',
       plainText: true,
+      structuredText: false,
       keyValuePairs: true,
       tables: true,
       language: 'english',
@@ -902,4 +903,289 @@ export const disabledImagesExample: BuildAPIArgs = {
     },
   },
   outputPath: 'output_pdf.pdf',
+}
+
+// Example with PDF/UA output for accessibility
+export const pdfUAExample: BuildAPIArgs = {
+  instructions: {
+    parts: [
+      {
+        file: 'example.pdf',
+      },
+    ],
+    output: {
+      type: 'pdfua',
+      metadata: {
+        title: 'Accessible Document',
+        author: 'Accessibility Team',
+      },
+    },
+  },
+  outputPath: 'output_pdfua.pdf',
+}
+
+// Example with PDF/UA output with password protection
+export const pdfUAWithPasswordExample: BuildAPIArgs = {
+  instructions: {
+    parts: [
+      {
+        file: 'example.pdf',
+      },
+    ],
+    output: {
+      type: 'pdfua',
+      user_password: 'user123',
+      owner_password: 'owner456',
+      user_permissions: ['printing', 'extract_accessibility', 'fill_forms'],
+      metadata: {
+        title: 'Protected Accessible Document',
+        author: 'Security Team',
+      },
+    },
+  },
+  outputPath: 'output_pdfua_protected.pdf',
+}
+
+// Example with HTML output using page layout
+export const htmlPageLayoutExample: BuildAPIArgs = {
+  instructions: {
+    parts: [
+      {
+        file: 'example.pdf',
+      },
+    ],
+    output: {
+      type: 'html',
+      layout: 'page',
+    },
+  },
+  outputPath: 'output_page.html',
+}
+
+// Example with HTML output using reflow layout
+export const htmlReflowLayoutExample: BuildAPIArgs = {
+  instructions: {
+    parts: [
+      {
+        file: 'example.pdf',
+      },
+    ],
+    output: {
+      type: 'html',
+      layout: 'reflow',
+    },
+  },
+  outputPath: 'output_reflow.html',
+}
+
+// Example with HTML output (default layout)
+export const htmlDefaultExample: BuildAPIArgs = {
+  instructions: {
+    parts: [
+      {
+        file: 'example.pdf',
+      },
+    ],
+    output: {
+      type: 'html',
+    },
+  },
+  outputPath: 'output.html',
+}
+
+// Example with Markdown output
+export const markdownExample: BuildAPIArgs = {
+  instructions: {
+    parts: [
+      {
+        file: 'example.pdf',
+      },
+    ],
+    output: {
+      type: 'markdown',
+    },
+  },
+  outputPath: 'output.md',
+}
+
+// Example with Markdown output from multiple sources
+export const markdownMultipleSourcesExample: BuildAPIArgs = {
+  instructions: {
+    parts: [
+      {
+        file: 'example.pdf',
+        pages: { start: 0, end: 2 },
+      },
+      {
+        file: 'example.docx',
+      },
+    ],
+    output: {
+      type: 'markdown',
+    },
+  },
+  outputPath: 'output_combined.md',
+}
+
+// Example with JSON content extraction including structured text
+export const jsonContentWithStructuredTextExample: BuildAPIArgs = {
+  instructions: {
+    parts: [
+      {
+        file: 'example.pdf',
+      },
+    ],
+    output: {
+      type: 'json-content',
+      plainText: false,
+      structuredText: true,
+      keyValuePairs: false,
+      tables: false,
+      language: 'english',
+    },
+  },
+  outputPath: 'output_structured.json',
+}
+
+// Example with JSON content extraction for key-value pairs only
+export const jsonContentKeyValuePairsExample: BuildAPIArgs = {
+  instructions: {
+    parts: [
+      {
+        file: 'example.pdf',
+      },
+    ],
+    output: {
+      type: 'json-content',
+      plainText: false,
+      structuredText: false,
+      keyValuePairs: true,
+      tables: false,
+      language: 'english',
+    },
+  },
+  outputPath: 'output_kvp.json',
+}
+
+// Example with JSON content extraction for tables only
+export const jsonContentTablesOnlyExample: BuildAPIArgs = {
+  instructions: {
+    parts: [
+      {
+        file: 'example.pdf',
+      },
+    ],
+    output: {
+      type: 'json-content',
+      plainText: false,
+      structuredText: false,
+      keyValuePairs: false,
+      tables: true,
+      language: 'english',
+    },
+  },
+  outputPath: 'output_tables.json',
+}
+
+// Example with JSON content extraction with multiple languages
+export const jsonContentMultiLanguageExample: BuildAPIArgs = {
+  instructions: {
+    parts: [
+      {
+        file: 'example.pdf',
+      },
+    ],
+    output: {
+      type: 'json-content',
+      plainText: true,
+      structuredText: false,
+      keyValuePairs: true,
+      tables: true,
+      language: ['english', 'spanish', 'french'],
+    },
+  },
+  outputPath: 'output_multilang.json',
+}
+
+// Complex example with OCR and HTML output
+export const ocrToHtmlExample: BuildAPIArgs = {
+  instructions: {
+    parts: [
+      {
+        file: 'example.pdf',
+      },
+    ],
+    actions: [
+      {
+        type: 'ocr',
+        language: 'english',
+      },
+    ],
+    output: {
+      type: 'html',
+      layout: 'reflow',
+    },
+  },
+  outputPath: 'output_ocr.html',
+}
+
+// Complex example with watermark and Markdown output
+export const watermarkToMarkdownExample: BuildAPIArgs = {
+  instructions: {
+    parts: [
+      {
+        file: 'example.pdf',
+      },
+    ],
+    actions: [
+      {
+        type: 'watermark',
+        watermarkType: 'text',
+        text: 'DRAFT',
+        width: 100,
+        height: 50,
+        opacity: 0.3,
+        rotation: 45,
+        fontColor: '#CCCCCC',
+      },
+    ],
+    output: {
+      type: 'markdown',
+    },
+  },
+  outputPath: 'output_watermarked.md',
+}
+
+// Example with redactions and PDF/UA output
+export const redactedPdfUAExample: BuildAPIArgs = {
+  instructions: {
+    parts: [
+      {
+        file: 'example.pdf',
+      },
+    ],
+    actions: [
+      {
+        type: 'createRedactions',
+        strategy: 'preset',
+        strategyOptions: {
+          preset: 'social-security-number',
+          includeAnnotations: true,
+          start: 0,
+          limit: null,
+        },
+      },
+      {
+        type: 'applyRedactions',
+      },
+    ],
+    output: {
+      type: 'pdfua',
+      metadata: {
+        title: 'Redacted Accessible Document',
+        author: 'Compliance Team',
+      },
+    },
+  },
+  outputPath: 'output_redacted_accessible.pdf',
 }

--- a/tests/build-api-examples.ts
+++ b/tests/build-api-examples.ts
@@ -923,28 +923,6 @@ export const pdfUAExample: BuildAPIArgs = {
   outputPath: 'output_pdfua.pdf',
 }
 
-// Example with PDF/UA output with password protection
-export const pdfUAWithPasswordExample: BuildAPIArgs = {
-  instructions: {
-    parts: [
-      {
-        file: 'example.pdf',
-      },
-    ],
-    output: {
-      type: 'pdfua',
-      user_password: 'user123',
-      owner_password: 'owner456',
-      user_permissions: ['printing', 'extract_accessibility', 'fill_forms'],
-      metadata: {
-        title: 'Protected Accessible Document',
-        author: 'Security Team',
-      },
-    },
-  },
-  outputPath: 'output_pdfua_protected.pdf',
-}
-
 // Example with HTML output using page layout
 export const htmlPageLayoutExample: BuildAPIArgs = {
   instructions: {

--- a/tests/build-api-examples.ts
+++ b/tests/build-api-examples.ts
@@ -108,7 +108,6 @@ export const jsonContentExtractionExample: BuildAPIArgs = {
     output: {
       type: 'json-content',
       plainText: true,
-      structuredText: false,
       keyValuePairs: true,
       tables: true,
       language: 'english',
@@ -1027,26 +1026,6 @@ export const markdownMultipleSourcesExample: BuildAPIArgs = {
   outputPath: 'output_combined.md',
 }
 
-// Example with JSON content extraction including structured text
-export const jsonContentWithStructuredTextExample: BuildAPIArgs = {
-  instructions: {
-    parts: [
-      {
-        file: 'example.pdf',
-      },
-    ],
-    output: {
-      type: 'json-content',
-      plainText: false,
-      structuredText: true,
-      keyValuePairs: false,
-      tables: false,
-      language: 'english',
-    },
-  },
-  outputPath: 'output_structured.json',
-}
-
 // Example with JSON content extraction for key-value pairs only
 export const jsonContentKeyValuePairsExample: BuildAPIArgs = {
   instructions: {
@@ -1058,7 +1037,6 @@ export const jsonContentKeyValuePairsExample: BuildAPIArgs = {
     output: {
       type: 'json-content',
       plainText: false,
-      structuredText: false,
       keyValuePairs: true,
       tables: false,
       language: 'english',
@@ -1078,7 +1056,6 @@ export const jsonContentTablesOnlyExample: BuildAPIArgs = {
     output: {
       type: 'json-content',
       plainText: false,
-      structuredText: false,
       keyValuePairs: false,
       tables: true,
       language: 'english',
@@ -1098,7 +1075,6 @@ export const jsonContentMultiLanguageExample: BuildAPIArgs = {
     output: {
       type: 'json-content',
       plainText: true,
-      structuredText: false,
       keyValuePairs: true,
       tables: true,
       language: ['english', 'spanish', 'french'],

--- a/tests/directoryTree.test.ts
+++ b/tests/directoryTree.test.ts
@@ -14,29 +14,26 @@ function createMockDirent(name: string, isDir: boolean = false): fs.Dirent {
 }
 
 describe('Directory Tree File Descriptor Handling', () => {
-  let mockClose: ReturnType<typeof vi.fn>;
-  let mockFileHandle: FileHandle;
+  let mockClose: ReturnType<typeof vi.fn>
+  let mockFileHandle: FileHandle
 
   beforeEach(() => {
     vi.resetAllMocks()
 
-    vi.spyOn(fs.promises, "access").mockResolvedValue(undefined)
+    vi.spyOn(fs.promises, 'access').mockResolvedValue(undefined)
     vi.spyOn(fs.promises, 'stat').mockResolvedValue({
       isFile: () => true,
       isDirectory: () => true,
     } as Stats)
 
-    const mockFiles = [
-      createMockDirent('file1.txt'),
-      createMockDirent('file2.pdf')
-    ];
+    const mockFiles = [createMockDirent('file1.txt'), createMockDirent('file2.pdf')]
 
-    vi.spyOn(fs.promises, "readdir").mockResolvedValue(mockFiles as unknown as fs.Dirent<Buffer<ArrayBufferLike>>[])
+    vi.spyOn(fs.promises, 'readdir').mockResolvedValue(mockFiles as unknown as fs.Dirent<Buffer<ArrayBufferLike>>[])
 
     mockClose = vi.fn().mockResolvedValue(undefined)
     mockFileHandle = {
       fd: 16,
-      close: mockClose
+      close: mockClose,
     } as unknown as FileHandle
   })
 
@@ -45,7 +42,7 @@ describe('Directory Tree File Descriptor Handling', () => {
   })
 
   it('should properly close file descriptors when processing files', async () => {
-    const openSpy = vi.spyOn(fs.promises, "open").mockResolvedValue(mockFileHandle)
+    const openSpy = vi.spyOn(fs.promises, 'open').mockResolvedValue(mockFileHandle)
 
     await performDirectoryTreeCall('/test/dir')
 
@@ -60,7 +57,8 @@ describe('Directory Tree File Descriptor Handling', () => {
   })
 
   it('should handle errors when opening files and continue processing', async () => {
-    const openSpy = vi.spyOn(fs.promises, "open")
+    const openSpy = vi
+      .spyOn(fs.promises, 'open')
       .mockRejectedValueOnce(new Error('Permission denied'))
       .mockResolvedValueOnce(mockFileHandle)
 
@@ -77,10 +75,10 @@ describe('Directory Tree File Descriptor Handling', () => {
     const specialMockClose = vi.fn().mockResolvedValue(undefined)
     const specialMockFileHandle = {
       fd: 42,
-      close: specialMockClose
+      close: specialMockClose,
     } as unknown as FileHandle
 
-    vi.spyOn(fs.promises, "open").mockResolvedValue(specialMockFileHandle)
+    vi.spyOn(fs.promises, 'open').mockResolvedValue(specialMockFileHandle)
 
     const fsCloseSpy = vi.spyOn(fs, 'close')
 

--- a/tests/signing-api-examples.test.ts
+++ b/tests/signing-api-examples.test.ts
@@ -19,7 +19,7 @@ describe('performSignCall with signing-api-examples', () => {
 
   afterEach(async () => {
     // A naive way to do rate limiting.
-    return await new Promise((resolve) => setTimeout(resolve, 5000))
+    return await new Promise((resolve) => setTimeout(resolve, 10000))
   }, 20000)
 
   const signatureExamples: { name: string; example: SignAPIArgs }[] = [

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -36,23 +36,22 @@ describe('API Functions', () => {
 
     process.env = { ...originalEnv, NUTRIENT_DWS_API_KEY: 'test-api-key' }
 
-    vi.spyOn(fs.promises, "access").mockImplementation(async () => {})
+    vi.spyOn(fs.promises, 'access').mockImplementation(async () => {})
     vi.spyOn(fs.promises, 'stat').mockReturnValue(
       Promise.resolve({
         isFile: () => true,
         isDirectory: () => true,
       } as Stats),
     )
-    vi.spyOn(fs.promises, "open").mockReturnValue(Promise.resolve({close: async () => {}} as FileHandle))
+    vi.spyOn(fs.promises, 'open').mockReturnValue(Promise.resolve({ close: async () => {} } as FileHandle))
 
-    vi.spyOn(fs.promises, "readFile").mockReturnValue(Promise.resolve(Buffer.from('test file content')))
-    vi.spyOn(fs.promises, "writeFile").mockImplementation(async () => {})
+    vi.spyOn(fs.promises, 'readFile').mockReturnValue(Promise.resolve(Buffer.from('test file content')))
+    vi.spyOn(fs.promises, 'writeFile').mockImplementation(async () => {})
 
-    vi.spyOn(fs.promises, "readdir").mockImplementation(() => Promise.resolve([]))
-    vi.spyOn(fs.promises, "mkdir").mockReturnValue(Promise.resolve(undefined))
-    vi.spyOn(fs.promises, "unlink").mockImplementation(async () => {})
-    vi.spyOn(fs.promises, "rm").mockImplementation(async () => {})
-
+    vi.spyOn(fs.promises, 'readdir').mockImplementation(() => Promise.resolve([]))
+    vi.spyOn(fs.promises, 'mkdir').mockReturnValue(Promise.resolve(undefined))
+    vi.spyOn(fs.promises, 'unlink').mockImplementation(async () => {})
+    vi.spyOn(fs.promises, 'rm').mockImplementation(async () => {})
 
     vi.mocked(api.callNutrientApi).mockImplementation(async () => {
       const mockStream = createMockStream('default mock response')
@@ -74,7 +73,9 @@ describe('API Functions', () => {
     it('should throw an error if file does not exist', async () => {
       const resolvedPath = path.resolve('/test.pdf')
 
-      vi.spyOn(fs.promises, "access").mockImplementation(async () => { throw new Error(`Path not found: ${resolvedPath}`)})
+      vi.spyOn(fs.promises, 'access').mockImplementation(async () => {
+        throw new Error(`Path not found: ${resolvedPath}`)
+      })
 
       const buildCall = performBuildCall({ parts: [{ file: '/test.pdf' }] }, '/test_processed.pdf')
 
@@ -231,7 +232,9 @@ describe('API Functions', () => {
     it('should throw an error if file does not exist', async () => {
       const resolvedPath = path.resolve('/test.pdf')
 
-      vi.spyOn(fs.promises, "access").mockImplementation(async () => { throw new Error(`Error with referenced file /test.pdf: Path not found: ${resolvedPath}`)})
+      vi.spyOn(fs.promises, 'access').mockImplementation(async () => {
+        throw new Error(`Error with referenced file /test.pdf: Path not found: ${resolvedPath}`)
+      })
 
       const buildCall = performBuildCall({ parts: [{ file: '/test.pdf' }] }, '/test_processed.pdf')
 
@@ -353,11 +356,13 @@ describe('API Functions', () => {
 
   describe('performDirectoryTreeCall', () => {
     it('should return a tree structure for a valid directory', async () => {
-      vi.spyOn(fs.promises, "access").mockImplementation(async () => {})
+      vi.spyOn(fs.promises, 'access').mockImplementation(async () => {})
 
-      vi.spyOn(fs.promises, "stat").mockReturnValue(Promise.resolve({
-        isDirectory: () => true,
-      } as Stats))
+      vi.spyOn(fs.promises, 'stat').mockReturnValue(
+        Promise.resolve({
+          isDirectory: () => true,
+        } as Stats),
+      )
 
       const mockEntries = [
         {
@@ -395,7 +400,7 @@ describe('API Functions', () => {
         },
       ]
 
-      vi.spyOn(fs.promises, "readdir").mockImplementationOnce(() =>
+      vi.spyOn(fs.promises, 'readdir').mockImplementationOnce(() =>
         Promise.resolve(mockEntries as unknown as fs.Dirent<Buffer<ArrayBufferLike>>[]),
       )
 
@@ -416,9 +421,11 @@ describe('API Functions', () => {
     })
 
     it('should return an error if the directory does not exist', async () => {
-      vi.spyOn(fs.promises, "stat").mockReturnValue(Promise.resolve({
-        isDirectory: () => false,
-      } as Stats))
+      vi.spyOn(fs.promises, 'stat').mockReturnValue(
+        Promise.resolve({
+          isDirectory: () => false,
+        } as Stats),
+      )
 
       const result = await performDirectoryTreeCall('/nonexistent/dir')
 
@@ -429,11 +436,13 @@ describe('API Functions', () => {
     })
 
     it('should return an error if the path is not a directory', async () => {
-      vi.spyOn(fs.promises, "access").mockImplementation(async () => {})
+      vi.spyOn(fs.promises, 'access').mockImplementation(async () => {})
 
-      vi.spyOn(fs.promises, "stat").mockReturnValue(Promise.resolve({
-        isDirectory: () => false,
-      } as Stats))
+      vi.spyOn(fs.promises, 'stat').mockReturnValue(
+        Promise.resolve({
+          isDirectory: () => false,
+        } as Stats),
+      )
 
       const result = await performDirectoryTreeCall('/test/file.txt')
 
@@ -442,13 +451,15 @@ describe('API Functions', () => {
     })
 
     it('should handle empty directories', async () => {
-      vi.spyOn(fs.promises, "access").mockImplementation(async () => {})
+      vi.spyOn(fs.promises, 'access').mockImplementation(async () => {})
 
-      vi.spyOn(fs.promises, "stat").mockReturnValue(Promise.resolve({
-        isDirectory: () => true,
-      } as Stats))
+      vi.spyOn(fs.promises, 'stat').mockReturnValue(
+        Promise.resolve({
+          isDirectory: () => true,
+        } as Stats),
+      )
 
-      vi.spyOn(fs.promises, "readdir").mockImplementation(() => Promise.resolve([] as unknown as fs.Dirent<Buffer>[]))
+      vi.spyOn(fs.promises, 'readdir').mockImplementation(() => Promise.resolve([] as unknown as fs.Dirent<Buffer>[]))
 
       const result = await performDirectoryTreeCall('/test/empty-dir')
 
@@ -459,19 +470,23 @@ describe('API Functions', () => {
     })
 
     it('should handle errors during tree building', async () => {
-      vi.spyOn(fs.promises, "access").mockImplementation(async () => {})
+      vi.spyOn(fs.promises, 'access').mockImplementation(async () => {})
 
-      vi.spyOn(fs.promises, "stat").mockReturnValue(Promise.resolve({
-        isDirectory: () => true,
-      } as Stats))
+      vi.spyOn(fs.promises, 'stat').mockReturnValue(
+        Promise.resolve({
+          isDirectory: () => true,
+        } as Stats),
+      )
 
       const mockError = new Error('Permission denied')
-      vi.spyOn(fs.promises, "readdir").mockImplementation(() => Promise.reject(mockError))
+      vi.spyOn(fs.promises, 'readdir').mockImplementation(() => Promise.reject(mockError))
 
       const result = await performDirectoryTreeCall('/test/dir')
 
       expect(result.isError).toBe(true)
-      expect(result.content[0].text).toContain('Cannot read the directory tree, make sure to allow this application access to')
+      expect(result.content[0].text).toContain(
+        'Cannot read the directory tree, make sure to allow this application access to',
+      )
     })
   })
 
@@ -479,18 +494,18 @@ describe('API Functions', () => {
     beforeEach(async () => {
       vi.resetAllMocks()
 
-      vi.spyOn(fs.promises, "access").mockImplementation(async () => {})
+      vi.spyOn(fs.promises, 'access').mockImplementation(async () => {})
       vi.spyOn(fs.promises, 'stat').mockReturnValue(
         Promise.resolve({
           isFile: () => true,
           isDirectory: () => true,
         } as Stats),
       )
-      vi.spyOn(fs.promises, "open").mockReturnValue(Promise.resolve({close: async () => {}} as FileHandle))
+      vi.spyOn(fs.promises, 'open').mockReturnValue(Promise.resolve({ close: async () => {} } as FileHandle))
 
-      vi.spyOn(fs.promises, "mkdir").mockReturnValue(Promise.resolve(undefined))
-      vi.spyOn(fs.promises, "unlink").mockImplementation(async () => {})
-      vi.spyOn(fs.promises, "rm").mockImplementation(async () => {})
+      vi.spyOn(fs.promises, 'mkdir').mockReturnValue(Promise.resolve(undefined))
+      vi.spyOn(fs.promises, 'unlink').mockImplementation(async () => {})
+      vi.spyOn(fs.promises, 'rm').mockImplementation(async () => {})
 
       await sandbox.setSandboxDirectory(null)
     })
@@ -503,7 +518,7 @@ describe('API Functions', () => {
 
         const resolvedAbsolutePathOutsideSandbox = path.resolve('/sandbox/outside/test.pdf')
 
-        const answerPath = await  sandbox.resolveReadFilePath(absolutePathOutsideSandbox)
+        const answerPath = await sandbox.resolveReadFilePath(absolutePathOutsideSandbox)
 
         // Paths should resolve inside the sandbox.
         expect(answerPath).toBe(resolvedAbsolutePathOutsideSandbox)

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -151,7 +151,6 @@ describe('API Functions', () => {
         parts: [{ file: 'https://example.com/test.pdf' }],
         output: {
           type: 'json-content',
-          structuredText: false,
           plainText: true,
           keyValuePairs: false,
           tables: true,

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -150,6 +150,7 @@ describe('API Functions', () => {
         parts: [{ file: 'https://example.com/test.pdf' }],
         output: {
           type: 'json-content',
+          structuredText: false,
           plainText: true,
           keyValuePairs: false,
           tables: true,


### PR DESCRIPTION
Adds newly supported output formats from DWS. 

-  PDF/UA: Accessible PDF format compliance
-  HTML: Web-ready document conversion
-  Markdown: Plain text markup output

Sorry there are a few formatting changes as it seems format was not run on all these files previously. 

![CleanShot 2025-07-03 at 11 58 26@2x](https://github.com/user-attachments/assets/d5089579-5a8c-41ec-8ed3-786cef153519)


