### PR TITLE
Support sandbox setting via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ This server allows AI assistants to access the tools provided by Nutrient DWS Pr
   "mcpServers": {
     "nutrient-dws": {
       "command": "npx",
-      "args": ["-y", "@nutrient-sdk/dws-mcp-server", "--sandbox", "/your/sandbox/directory"], // "C:\\your\\sandbox\\directory" for Windows
+      "args": ["-y", "@nutrient-sdk/dws-mcp-server"],
       "env": {
-        "NUTRIENT_DWS_API_KEY": "YOUR_API_KEY_HERE"
+        "NUTRIENT_DWS_API_KEY": "YOUR_API_KEY_HERE",
+        "SANDBOX_PATH": "/your/sandbox/directory"  // "C:\\your\\sandbox\\directory" for Windows
       }
     }
   }
@@ -82,11 +83,20 @@ Nutrient DWS MCP Server supports macOS and Windows for now. Feel free to open an
 
 The server supports an optional sandbox mode that restricts file operations to a specific directory. This is useful for security purposes, ensuring that the server can only read from and write to files within the specified directory. You should drop any documents you'd like to work on in this directory.
 
-To enable sandbox mode, use the `--sandbox` (or `-s`) command line argument followed by the path to the directory:
+To enable sandbox mode, use either the `--sandbox` (or `-s`) command line argument or the `SANDBOX_PATH` environment variable:
 
+**Command line argument:**
 ```bash
 npx @nutrient-sdk/dws-mcp-server --sandbox /path/to/sandbox/directory
 ```
+
+**Environment variable:**
+```bash
+export SANDBOX_PATH=/path/to/sandbox/directory
+npx @nutrient-sdk/dws-mcp-server
+```
+
+**Note:** Command line arguments take precedence over environment variables if both are specified.
 
 When sandbox mode is enabled:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { performDirectoryTreeCall } from './fs/directoryTree.js'
 import { setSandboxDirectory } from './fs/sandbox.js'
 import { createErrorResponse } from './responses.js'
 import { getVersion } from './version.js'
+import { parseSandboxPath } from './utils/sandbox.js'
 
 const server = new McpServer(
   {
@@ -99,24 +100,17 @@ Positioning:
 
 async function parseCommandLineArgs() {
   const args = process.argv.slice(2)
-  let sandboxDir: string | null = null
-
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--sandbox' || args[i] === '-s') {
-      if (i + 1 < args.length) {
-        sandboxDir = args[i + 1]
-        i++ // Skip the next argument as it's the directory path
-      } else {
-        await server.server.sendLoggingMessage({
-          level: 'error',
-          data: 'Error: --sandbox flag requires a directory path',
-        })
-        process.exit(1)
-      }
-    }
+  
+  try {
+    const sandboxDir = parseSandboxPath(args, process.env.SANDBOX_PATH) || null
+    return { sandboxDir }
+  } catch (error) {
+    await server.server.sendLoggingMessage({
+      level: 'error',
+      data: `Error: ${error instanceof Error ? error.message : String(error)}`,
+    })
+    process.exit(1)
   }
-
-  return { sandboxDir }
 }
 
 export async function runServer() {

--- a/src/utils/sandbox.ts
+++ b/src/utils/sandbox.ts
@@ -1,0 +1,23 @@
+/**
+ * Parses sandbox directory from command line arguments and environment variables.
+ * Command line arguments take precedence over environment variables.
+ * 
+ * @param args - Command line arguments (typically process.argv.slice(2))
+ * @param envVar - Environment variable value (typically process.env.SANDBOX_PATH)
+ * @returns The sandbox directory path or undefined if none specified
+ */
+export function parseSandboxPath(args: string[], envVar?: string): string | undefined {
+  // Check command line arguments first (higher precedence)
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--sandbox' || args[i] === '-s') {
+      if (i + 1 < args.length) {
+        return args[i + 1]
+      } else {
+        throw new Error('--sandbox flag requires a directory path')
+      }
+    }
+  }
+
+  // Fall back to environment variable
+  return envVar || undefined
+}

--- a/tests/build-api-examples.test.ts
+++ b/tests/build-api-examples.test.ts
@@ -60,7 +60,6 @@ describe('performBuildCall with build-api-examples', () => {
     { name: 'ocrAndRedactionsExample', example: examples.ocrAndRedactionsExample },
     { name: 'disabledImagesExample', example: examples.disabledImagesExample },
     { name: 'pdfUAExample', example: examples.pdfUAExample },
-    { name: 'pdfUAWithPasswordExample', example: examples.pdfUAWithPasswordExample },
     { name: 'htmlPageLayoutExample', example: examples.htmlPageLayoutExample },
     { name: 'htmlReflowLayoutExample', example: examples.htmlReflowLayoutExample },
     { name: 'htmlDefaultExample', example: examples.htmlDefaultExample },


### PR DESCRIPTION
In order to make a submission to the Claude connectors registry, it made more sense to expose the sandbox path via environment variables. It mades things easier to express this optional value in the DXT manifest JSON (https://github.com/anthropics/dxt).

Updated the README to perfer this method and in the future we may deprecate the argument on the cli.