### PR TITLE
feat: add applyInstantJson build action for form filling

### DIFF
--- a/src/dws/build.ts
+++ b/src/dws/build.ts
@@ -88,6 +88,10 @@ async function processActionFileReferences(action: Action): Promise<FileReferenc
     const fileReference = await processFileReference(action.file)
     action.file = fileReference.key
     return fileReference
+  } else if (action.type === 'applyInstantJson' && 'file' in action && typeof action.file === 'string') {
+    const fileReference = await processFileReference(action.file)
+    action.file = fileReference.key
+    return fileReference
   }
 
   // No need to parse files for the other actions

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -197,6 +197,21 @@ export const ApplyXfdfActionSchema = z.object({
     ),
 })
 
+export const ApplyInstantJsonActionSchema = z.object({
+  type: z
+    .literal('applyInstantJson')
+    .describe(
+      'Apply Instant JSON to the document. Used for filling PDF form fields, creating form fields, ' +
+        'and importing annotations. The file should be in Nutrient Instant JSON format.',
+    ),
+  file: z
+    .string()
+    .describe(
+      'The path to the Instant JSON file or a reference to a file in the multipart request. ' +
+        'Resolves to sandbox path if enabled, otherwise resolves to the local file system.',
+    ),
+})
+
 export const FlattenActionSchema = z.object({
   type: z.literal('flatten').describe('Flatten the annotations in the document.'),
 
@@ -359,8 +374,7 @@ export const ApplyRedactionsActionSchema = z.object({
 })
 
 export const BuildActionSchema = z.discriminatedUnion('type', [
-  // For now, we will not support applying Instant JSON.
-  // ApplyInstantJsonActionSchema,
+  ApplyInstantJsonActionSchema,
   ApplyXfdfActionSchema,
   FlattenActionSchema,
   OcrActionSchema,

--- a/tests/build-api-examples.ts
+++ b/tests/build-api-examples.ts
@@ -290,6 +290,27 @@ export const applyXfdfExample: BuildAPIArgs = {
   outputPath: 'output_pdf.pdf',
 }
 
+// Example with applying Instant JSON
+export const applyInstantJsonExample: BuildAPIArgs = {
+  instructions: {
+    parts: [
+      {
+        file: 'example.pdf',
+      },
+    ],
+    actions: [
+      {
+        type: 'applyInstantJson',
+        file: 'example.json',
+      },
+    ],
+    output: {
+      type: 'pdf',
+    },
+  },
+  outputPath: 'output_pdf.pdf',
+}
+
 // Example with redactions using preset
 export const redactionsPresetExample: BuildAPIArgs = {
   instructions: {

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import fs, { Stats } from 'fs'
 import { Readable } from 'stream'
-import { AiRedactArgsSchema, Instructions, SignatureOptions } from '../src/schemas.js'
+import { AiRedactArgsSchema, BuildActionSchema, Instructions, SignatureOptions } from '../src/schemas.js'
 import { config as dotenvConfig } from 'dotenv'
 import { performBuildCall } from '../src/dws/build.js'
 import { performSignCall } from '../src/dws/sign.js'
@@ -39,6 +39,20 @@ function createMockStream(content: string | Buffer): Readable {
   })
   return readable
 }
+
+describe('BuildActionSchema', () => {
+  it('should parse applyInstantJson actions', () => {
+    const result = BuildActionSchema.safeParse({ type: 'applyInstantJson', file: '/test.json' })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('should reject applyInstantJson actions without a file', () => {
+    const result = BuildActionSchema.safeParse({ type: 'applyInstantJson' })
+
+    expect(result.success).toBe(false)
+  })
+})
 
 describe('API Functions', () => {
   const originalEnv = process.env


### PR DESCRIPTION
## Summary

Adds the `applyInstantJson` build action for PDF form filling and annotation import.

### Changes

**Schema:**
- `ApplyInstantJsonActionSchema` — applies Instant JSON to documents for:
  - Filling PDF form fields
  - Creating form fields
  - Importing annotations
- Added to `BuildActionSchema` discriminated union

**Tests:**
- Schema validation test (valid input)
- Schema rejection test (missing `file` property)

### Testing

- Build compiles clean
- 42 tests passing (2 new tests)

### Documentation

See [Instant JSON documentation](https://www.nutrient.io/guides/web/json-formats/instant-json/) for format details.

---

*Split from #12 per review feedback to keep PRs focused and reviewable.*