### PR TITLE
docs: add MCP server comparison and role framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,19 @@
 
 A Model Context Protocol (MCP) server that connects AI assistants to the [Nutrient Document Web Service (DWS) Processor API](https://www.nutrient.io/api) — enabling document creation, editing, conversion, digital signing, OCR, redaction, and more through natural language.
 
+## Which MCP Server Should I Use?
+
+| Server | Best for | Deployment | Core capabilities |
+|---|---|---|---|
+| [Nutrient DWS MCP Server](https://github.com/PSPDFKit/nutrient-dws-mcp-server) | Cloud document workflows | Nutrient-hosted API (API key) | Convert, OCR, redact, sign, extract, watermark, automation |
+| [Nutrient Document Engine MCP Server](https://github.com/PSPDFKit/nutrient-document-engine-mcp-server) | Self-hosted document workflows | On-prem/private cloud | Document processing with deployment control and data residency |
+| [Nutrient PDF MCP Server](https://github.com/PSPDFKit/nutrient-pdf-mcp-server) | Low-level PDF inspection/debugging | Local Python runtime | Object-tree exploration, indirect-object resolution, structural analysis |
+
+You are in the **DWS MCP Server** repo. Choose this when you want the fastest path to cloud-powered, production document workflows.
+
+- Ecosystem overview: [Nutrient AI Infrastructure](https://www.nutrient.io/ai/infrastructure/)
+- Product landing page: [Nutrient MCP Server](https://www.nutrient.io/mcp-server-pdf-automation-llm/)
+
 ## What You Can Do
 
 Once configured, you (or your AI agent) can process documents through natural language:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ A Model Context Protocol (MCP) server that connects AI assistants to the [Nutrie
 |---|---|---|---|
 | [Nutrient DWS MCP Server](https://github.com/PSPDFKit/nutrient-dws-mcp-server) | Cloud document workflows | Nutrient-hosted API (API key) | Convert, OCR, redact, sign, extract, watermark, automation |
 | [Nutrient Document Engine MCP Server](https://github.com/PSPDFKit/nutrient-document-engine-mcp-server) | Self-hosted document workflows | On-prem/private cloud | Document processing with deployment control and data residency |
-| [Nutrient PDF MCP Server](https://github.com/PSPDFKit/nutrient-pdf-mcp-server) | Low-level PDF inspection/debugging | Local Python runtime | Object-tree exploration, indirect-object resolution, structural analysis |
 
 You are in the **DWS MCP Server** repo. Choose this when you want the fastest path to cloud-powered, production document workflows.
 


### PR DESCRIPTION
## Summary
- add a shared "Which MCP Server Should I Use?" comparison table near the top of the README
- clarify DWS MCP role vs Document Engine MCP and PDF MCP
- add links to AI infrastructure and MCP landing pages for ecosystem navigation

## Validation
- docs-only change
- /review run and passed with no findings