### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,15 +18,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: pnpm


### PR DESCRIPTION
## What changed

Pinned the external GitHub Actions used by `.github/workflows/tests.yml` to verified full-length commit SHAs while preserving `# v4` comments for human-readable release context.

## Why

Mutable action refs such as `@v4` can move without any repository change. Pinning to commit SHAs reduces the supply-chain risk from moved tags or compromised upstream action repositories.

## Validation

Verified each upstream `v4` tag with `git ls-remote --tags` against the official action repositories. `pnpm/action-setup@v4` is an annotated tag, so the workflow pins the peeled commit from `refs/tags/v4^{}`. Also checked that no remaining workflow `uses:` refs point at mutable refs and ran `git diff --check`.

`pnpm exec actionlint` could not run locally because the repository does not configure a pnpm version for the active local tool manager.