### PR TITLE
refactor: authenticate Data Extraction via OAuth instead of a separate API key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,2 @@
 # Used in testing
-# Processor API key (build/sign/redact/credits tools)
 NUTRIENT_DWS_API_KEY=your-nutrient-dws-api-key
-
-# Separate Data Extraction API key (data_extractor tool). Starts with pdf_live_ / pdf_test_.
-NUTRIENT_EXTRACTION_API_KEY=your-nutrient-data-extraction-api-key

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Place documents in your sandbox directory and use explicit file names or paths i
 
 ### Data Extraction
 
-The `data_extractor` and `query_extraction` tools wrap the standalone [DWS Data Extraction API](https://www.nutrient.io/guides/dws-data-extraction/). They authenticate with a **separate** `NUTRIENT_EXTRACTION_API_KEY` (it starts with `pdf_live_`), independent of the Processor `NUTRIENT_DWS_API_KEY`.
+The `data_extractor` and `query_extraction` tools wrap the [DWS Data Extraction API](https://www.nutrient.io/guides/dws-data-extraction/). They authenticate the same way as every other tool — set `NUTRIENT_DWS_API_KEY`, or omit it and use the OAuth browser flow. No extra configuration is needed.
 
 `data_extractor` runs one of four processing modes:
 
@@ -310,16 +310,15 @@ When no API key is configured, the server stays connected and opens a browser-ba
 
 ### Environment Variables
 
-| Variable                      | Required    | Description                                                                                                                   |
-| ----------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `NUTRIENT_DWS_API_KEY`        | No\*        | Nutrient DWS **Processor** API key ([get one free](https://dashboard.nutrient.io/sign_up/))                                   |
-| `NUTRIENT_EXTRACTION_API_KEY` | No          | Nutrient DWS **Data Extraction** API key (separate key, starts with `pdf_live_`). Required only for the `data_extractor` tool |
-| `SANDBOX_PATH`                | Recommended | Directory to restrict file operations to                                                                                      |
-| `AUTH_SERVER_URL`             | No          | OAuth server base URL (default: `https://api.nutrient.io`)                                                                    |
-| `CLIENT_ID`                   | No          | OAuth client ID. Skips DCR and enables refresh token reuse when set                                                           |
-| `DWS_API_BASE_URL`            | No          | DWS API base URL (default: `https://api.nutrient.io`)                                                                         |
-| `LOG_LEVEL`                   | No          | Winston logger level (`info` default). Logs are written to `MCP_LOG_FILE` in stdio mode                                       |
-| `MCP_LOG_FILE`                | No          | Override log file path (default: system temp directory)                                                                       |
+| Variable               | Required    | Description                                                                             |
+| ---------------------- | ----------- | --------------------------------------------------------------------------------------- |
+| `NUTRIENT_DWS_API_KEY` | No\*        | Nutrient DWS API key ([get one free](https://dashboard.nutrient.io/sign_up/))           |
+| `SANDBOX_PATH`         | Recommended | Directory to restrict file operations to                                                |
+| `AUTH_SERVER_URL`      | No          | OAuth server base URL (default: `https://api.nutrient.io`)                              |
+| `CLIENT_ID`            | No          | OAuth client ID. Skips DCR and enables refresh token reuse when set                     |
+| `DWS_API_BASE_URL`     | No          | DWS API base URL (default: `https://api.nutrient.io`)                                   |
+| `LOG_LEVEL`            | No          | Winston logger level (`info` default). Logs are written to `MCP_LOG_FILE` in stdio mode |
+| `MCP_LOG_FILE`         | No          | Override log file path (default: system temp directory)                                 |
 
 \* If omitted, the server uses an OAuth browser flow to authenticate with the Nutrient API.
 

--- a/examples/invoice-extraction-workflow.md
+++ b/examples/invoice-extraction-workflow.md
@@ -7,8 +7,7 @@ extract structured data, branch on it, then act.
 
 **Prerequisites**
 
-- `NUTRIENT_EXTRACTION_API_KEY` (Data Extraction API key, starts with `pdf_live_`) for `data_extractor`.
-- `NUTRIENT_DWS_API_KEY` (or OAuth) for the `ai_redactor` / `document_signer` "act" steps.
+- `NUTRIENT_DWS_API_KEY` (or OAuth) for every step below.
 - `SANDBOX_PATH` set to a directory containing `invoice.pdf`.
 
 ## Step 1 — Extract structured elements to a file

--- a/src/dws/extract.ts
+++ b/src/dws/extract.ts
@@ -89,17 +89,7 @@ async function writeToResolvedPath(resolvedPath: string, data: string): Promise<
  * Spatial output is written to `outputPath` and summarized inline; markdown
  * output is returned inline.
  */
-export async function performExtractCall(
-  args: DataExtractorArgs,
-  extractionApiClient: DwsApiClient | undefined,
-): Promise<CallToolResult> {
-  if (!extractionApiClient) {
-    return createErrorResponse(
-      'Error: Data Extraction is not configured. Set the NUTRIENT_EXTRACTION_API_KEY environment variable ' +
-        '(a Data Extraction API key from the Nutrient dashboard, starting with pdf_live_ or pdf_test_).',
-    )
-  }
-
+export async function performExtractCall(args: DataExtractorArgs, apiClient: DwsApiClient): Promise<CallToolResult> {
   const { filePath, mode, language, includeWords, outputPath } = args
   const format = resolveFormat(mode, args.format)
 
@@ -152,7 +142,7 @@ export async function performExtractCall(
     form.append('file', fileBuffer, { filename: fileName })
     form.append('instructions', JSON.stringify(instructions))
 
-    const response = await extractionApiClient.post(EXTRACTION_ENDPOINT, form)
+    const response = await apiClient.post(EXTRACTION_ENDPOINT, form)
     const body = await pipeToString(response.data)
 
     let parsed: ExtractionResponse

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,13 +35,8 @@ import { getToken, invalidateCachedToken, type NutrientOAuthConfig } from './aut
 import { Environment, getEnvironment } from './utils/environment.js'
 import { logger } from './logger.js'
 
-function addToolsToServer(options: {
-  server: McpServer
-  sandboxEnabled: boolean
-  apiClient: DwsApiClient
-  extractionApiClient?: DwsApiClient
-}) {
-  const { server, sandboxEnabled, apiClient, extractionApiClient } = options
+function addToolsToServer(options: { server: McpServer; sandboxEnabled: boolean; apiClient: DwsApiClient }) {
+  const { server, sandboxEnabled, apiClient } = options
 
   server.tool(
     'document_processor',
@@ -191,7 +186,7 @@ Note: markdown output and any extracted content are returned into this conversat
     },
     async (args) => {
       try {
-        return await performExtractCall(args, extractionApiClient)
+        return await performExtractCall(args, apiClient)
       } catch (error) {
         return createErrorResponse(`Error: ${error instanceof Error ? error.message : String(error)}`)
       }
@@ -257,11 +252,7 @@ Use this to pull just the elements you need (e.g. low-confidence fields, or ever
   }
 }
 
-export function createMcpServer(options: {
-  sandboxEnabled: boolean
-  apiClient: DwsApiClient
-  extractionApiClient?: DwsApiClient
-}) {
+export function createMcpServer(options: { sandboxEnabled: boolean; apiClient: DwsApiClient }) {
   const server = new McpServer(
     {
       name: 'nutrient-dws-mcp-server',
@@ -279,26 +270,9 @@ export function createMcpServer(options: {
     server,
     sandboxEnabled: options.sandboxEnabled,
     apiClient: options.apiClient,
-    extractionApiClient: options.extractionApiClient,
   })
 
   return server
-}
-
-/**
- * Builds the Data Extraction API client when NUTRIENT_EXTRACTION_API_KEY is set.
- * Returns undefined otherwise, in which case data_extractor reports a clear
- * "set NUTRIENT_EXTRACTION_API_KEY" error when invoked.
- */
-function createExtractionApiClient(environment: Environment): DwsApiClient | undefined {
-  if (!environment.extractionApiKey) {
-    return undefined
-  }
-
-  return createApiClient({
-    apiKey: environment.extractionApiKey,
-    baseUrl: environment.dwsApiBaseUrl,
-  })
 }
 
 async function parseCommandLineArgs() {
@@ -325,7 +299,7 @@ function buildOAuthConfig(environment: Environment): NutrientOAuthConfig {
     tokenUrl: `${environment.authServerUrl}/oauth/token`,
     registrationUrl: `${environment.authServerUrl}/oauth/register`,
     clientId: environment.clientId,
-    scopes: ['mcp:invoke', 'offline_access'],
+    scopes: ['mcp:invoke', 'product:all', 'offline_access'],
     resource: environment.dwsApiBaseUrl,
   }
 }
@@ -366,12 +340,10 @@ export async function runServer(environment: Environment): Promise<RunServerResu
   })
 
   const apiClient = createStdioApiClient(environment)
-  const extractionApiClient = createExtractionApiClient(environment)
 
   const server = createMcpServer({
     sandboxEnabled,
     apiClient,
-    extractionApiClient,
   })
 
   const transport = new StdioServerTransport()

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -2,7 +2,6 @@ import { z } from 'zod'
 
 export type Environment = {
   nutrientApiKey?: string
-  extractionApiKey?: string
   dwsApiBaseUrl: string
   authServerUrl: string
   clientId?: string
@@ -10,9 +9,6 @@ export type Environment = {
 
 const RawEnvironmentSchema = z.object({
   NUTRIENT_DWS_API_KEY: z.string().optional(),
-  // Separate key for the standalone DWS Data Extraction API (POST /extraction/parse).
-  // Distinct from the Processor key above; starts with `pdf_live_` / `pdf_test_`.
-  NUTRIENT_EXTRACTION_API_KEY: z.string().optional(),
   DWS_API_BASE_URL: z.string().url().default('https://api.nutrient.io'),
   AUTH_SERVER_URL: z
     .string()
@@ -30,7 +26,6 @@ export function getEnvironment(rawEnv: NodeJS.ProcessEnv = process.env): Environ
 
   return {
     nutrientApiKey: raw.NUTRIENT_DWS_API_KEY,
-    extractionApiKey: raw.NUTRIENT_EXTRACTION_API_KEY,
     dwsApiBaseUrl: raw.DWS_API_BASE_URL,
     authServerUrl: raw.AUTH_SERVER_URL,
     clientId: raw.CLIENT_ID,

--- a/tests/environment.test.ts
+++ b/tests/environment.test.ts
@@ -10,19 +10,6 @@ describe('environment', () => {
     expect(environment.authServerUrl).toBe('https://api.nutrient.io')
   })
 
-  it('parses the separate Data Extraction API key', () => {
-    const environment = getEnvironment({ NUTRIENT_EXTRACTION_API_KEY: 'pdf_live_abc123' })
-
-    expect(environment.extractionApiKey).toBe('pdf_live_abc123')
-    expect(environment.nutrientApiKey).toBeUndefined()
-  })
-
-  it('leaves the extraction key undefined when unset', () => {
-    const environment = getEnvironment({ NUTRIENT_DWS_API_KEY: 'dws-key' })
-
-    expect(environment.extractionApiKey).toBeUndefined()
-  })
-
   it('allows overriding DWS API base URL', () => {
     const environment = getEnvironment({ DWS_API_BASE_URL: 'http://localhost:4000' })
 

--- a/tests/extract.test.ts
+++ b/tests/extract.test.ts
@@ -201,18 +201,6 @@ describe('performExtractCall', () => {
     expect(result.isError).toBeFalsy()
     await expect(fs.promises.access(escape)).rejects.toThrow()
   })
-
-  it('returns a clear setup error when the extraction client is not configured', async () => {
-    const input = await writeInput()
-
-    const result = await performExtractCall(
-      extractArgs({ filePath: input, mode: 'text', format: 'markdown' }),
-      undefined,
-    )
-
-    expect(result.isError).toBe(true)
-    expect(text(result)).toContain('NUTRIENT_EXTRACTION_API_KEY')
-  })
 })
 
 describe('performQueryCall', () => {


### PR DESCRIPTION
## Why

`data_extractor` authenticated with its own `NUTRIENT_EXTRACTION_API_KEY` against a second `DwsApiClient`, separate from the key every other tool uses. That was a workaround, not a design: the Data Extraction API previously accepted only static API keys, and OAuth access tokens were scoped to a single product, so a token that worked for Processor could not reach Data Extraction.

That constraint is gone. DWS now issues organization-scoped OAuth access tokens and accepts them on the Data Extraction API under the `product:data_extraction` scope. A single token covers both products.

Keeping the separate key would have meant this server's newest tool was the only one that could not use the OAuth browser flow — asking users to provision a second key for one tool, and stepping around the OAuth support the server already had.

## Summary

- `data_extractor` now uses the same `DwsApiClient` as `document_processor`, `document_signer`, `ai_redactor`, and `check_credits`, so it inherits the existing API-key-or-OAuth-browser-flow path.
- Removed `NUTRIENT_EXTRACTION_API_KEY`, the second client, and the "extraction is not configured" error branch. Making the client non-optional removes a class of silent misconfiguration.
- Request `product:all` explicitly in the OAuth scopes rather than relying on the server to infer a product scope.
- Docs updated: extraction is described as using the same auth as every other tool. The modes/cost table, spatial-vs-markdown guidance, query workflow, and sensitive-content note are unchanged.
- Deleted the three tests that asserted the removed separate-key behaviour.

Net −92 / +18 across 8 files. The `resource` parameter is unchanged (`https://api.nutrient.io`).

## Verification

**Automated** — `pnpm run build` clean, `pnpm run lint` clean, `pnpm run test:ci` **117/117 passing** (was 120; the 3 removed tests covered the deleted behaviour). `grep -ri "NUTRIENT_EXTRACTION_API_KEY|extractionApiKey|extractionApiClient" src tests README.md examples .env.example` returns nothing.

**Live, end-to-end against production** — ran the built server over stdio with **no** `NUTRIENT_DWS_API_KEY` and no cached credentials, forcing a real OAuth browser flow (DCR registration → browser consent → token). Four tool calls, all OK:

| Call | Product | Result |
| --- | --- | --- |
| `check_credits` | Processor | `enterprise`, credits returned, `signedIn: true` |
| `data_extractor` `mode=text format=markdown` | Data Extraction | Markdown returned inline, 6 pages |
| `data_extractor` `mode=structure format=spatial` | Data Extraction | 6 elements → `extraction.json`, content-free summary |
| `query_extraction` | local | 3 elements with bounds, no API call |

The point: **Processor and Data Extraction were served by the same OAuth token in one session** — exactly what the separate key existed to work around.

Authorize URL issued by the server:

```
scope=mcp%3Ainvoke+product%3Aall+offline_access
resource=https%3A%2F%2Fapi.nutrient.io
```

Decoded access token (account identifiers redacted):

```
scope:           mcp:invoke product:all offline_access
aud:             https://api.nutrient.io
organization_id: <redacted>          (no tenant_id — organization-scoped)
```

`product:all` was granted as requested, confirming the scope choice against a live grant rather than inference. The production discovery document independently advertises both `product:all` and `product:data_extraction` in `scopes_supported`.

## Notes for review

- Based on #27 rather than `main`, so this targets that branch and shows only the auth rework. Happy to retarget to `main` if it is preferred that this supersede #27.
- `product:all` was chosen over `product:processor product:data_extraction` because it matches the server's advertised default scope set, and will not silently break if a future tool wraps a third product.
