### PR TITLE
Bump version to 0.1.0 for data extraction support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "nutrient-dws-mcp-server",
   "display_name": "Nutrient DWS",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "description": "Process, sign, redact, and transform documents from Claude Desktop using Nutrient.",
   "long_description": "A local Claude Desktop extension for document processing with Nutrient. It runs as a stdio MCP server, reads files from a user-selected sandbox directory, opens a browser for OAuth on the first request that uses the Nutrient API, and writes processed results back to local output paths.",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nutrient-sdk/dws-mcp-server",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "description": "MCP server for Nutrient DWS Processor API",
   "license": "MIT",
   "author": "Nutrient (https://www.nutrient.io)",


### PR DESCRIPTION
## Summary

Minor version bump `0.0.6` → `0.1.0` to reflect the new document data extraction workflow (extract/parse) landed on `main`.

- Bump `version` in `package.json`
- Sync `manifest.json` version via the `manifest:sync-version` script

## Verification

- `pnpm run manifest:sync-version` ran clean; both files report `0.1.0`:
  ```
  package.json:  "version": "0.1.0",
  manifest.json: "version": "0.1.0",
  ```
- `git diff` confirms the change is isolated to the two version lines — no other files touched.
- Checked `pnpm-lock.yaml` carries no root-package version reference, so no lockfile update is needed.
