### PR TITLE
Fix prepublishOnly failing under npm publish on pnpm 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "test:integration": "vitest run tests/build-api-examples.test.ts tests/signing-api-examples.test.ts",
     "test:watch": "vitest",
     "clean": "shx rm -rf dist",
-    "prepublishOnly": "pnpm run build"
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.2",


### PR DESCRIPTION
## Summary

The documented `npm publish` release flow is currently broken on pnpm 10. `npm publish` runs `prepublishOnly` → `pnpm run build`, spawning pnpm **nested inside** `npm publish`. Under npm's exported lifecycle environment, pnpm 10 evaluates the packages-less `pnpm-workspace.yaml` (which exists only to declare `supportedArchitectures`) in strict workspace mode and aborts with:

```
ERROR  packages field missing or empty
```

…so the publish fails before uploading anything.

This routes the prepublish build through `npm run build` instead. `npm` is already the process running publish, and the `build` script (`tsc && shx chmod +x dist/index.js`) never invokes pnpm, so the nested workspace evaluation no longer happens. Single-line change, no behavior change to the build output.

## Verification

Before (broken) — `prepublishOnly: "pnpm run build"`:

```
> pnpm run build
 ERROR  packages field missing or empty
npm error command failed
npm error command sh -c pnpm run build
```

After (this change) — `prepublishOnly: "npm run build"`, full dry-run with scripts enabled:

```
$ npm publish --dry-run --access public
...
npm notice total files: 24
npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access (dry-run)
+ @nutrient-sdk/dws-mcp-server@0.1.0
```

- Tarball unchanged: 24 files, `dist/` + README + LICENSE, 44.3 kB.
- `pnpm build` (direct dev build) continues to work — this only affects the publish lifecycle path.

## Note

The same fix likely applies to `nutrient-document-engine-mcp-server`, which shares this release flow.
